### PR TITLE
Add multi-threading and GRPC connection tests

### DIFF
--- a/.github/workflows/conneciton_tests.yaml
+++ b/.github/workflows/conneciton_tests.yaml
@@ -1,0 +1,36 @@
+name: Long-standing connection test
+
+# on:
+#   schedule:
+#     - cron: '0 0 * * *'
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 'pypy3.9' 
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install Build Dependencies
+        run: sudo apt-get -y update && sudo apt-get -y install pkg-config libssl-dev clang
+      - name: Install protoc
+        run: sudo apt install -y protobuf-compiler libprotobuf-dev
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/unit/requirements.txt
+
+      - name: Run long-standing connection test
+        run: |
+          pytest tests/grpc/test_multi_thread.py
+            make long-running-test

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ clean:
 
 generate-index-service:
 	docker run --rm -v "${CURDIR}:/local" openapitools/openapi-generator-cli generate --input-spec /local/openapi/index_service.json  --generator-name rust  --output /local/index_service --additional-properties packageName=index_service --additional-properties packageVersion=0.1.0 --additional-properties withSerde=true  --additional-properties supportMultipleResponses=true
+
+long-running-test: venv develop
+	pytest tests/grpc/test_multi_thread.py

--- a/README.md
+++ b/README.md
@@ -277,42 +277,6 @@ asyncio.run(async_upload(index, vectors, batch_size=100))
 # In a jupyter notebook, asyncio.run() is not supported. Instead, use
 await async_upload(index, vectors, batch_size=100)  
 ```
-
-#### TODO: Decide if we want to suggest this longer, more verbose version, which includes a progress bar and return type: 
-
-```python
-from tqdm.asyncio import tqdm
-import asyncio
-from pinecone import UpsertResponse, Client, Vector
-
-def chunker(seq, batch_size):
-    return (seq[pos:pos + batch_size] for pos in range(0, len(seq), batch_size))
-
-async def async_upload(index, vectors, batch_size, max_concurrent=50):
-    sem = asyncio.Semaphore(max_concurrent)
-    async def send_batch(batch):
-        async with sem:
-            return await index.upsert(vectors=batch, async_req=True)
-
-    tasks = [send_batch(chunk) for chunk in chunker(vectors, batch_size=batch_size)]
-    pbar = tqdm(total=len(vectors), desc="upserted vectors")
-    total_upserted_count = 0
-    for task in asyncio.as_completed(tasks):
-        res = await task
-        total_upserted_count += res.upserted_count
-        pbar.update(res.upserted_count)
-    return UpsertResponse(upserted_count=total_upserted_count)
-
-# To use it:
-client = Client()
-index = client.get_index("example-index")
-vectors = [Vector(id=f"vec{i}", values=[1.0, 2.0, 3.0]) for i in range(1000)]
-res = asyncio.run(async_upload(index, vectors, batch_size=100))
-
-# In a jupyter notebook, asyncio.run() is not supported. Instead, use
-res = await async_upload(index, vectors, batch_size=100)  
-```
-
 # Limitations
 
 ## Code completion and type hints

--- a/pinecone/src/index.rs
+++ b/pinecone/src/index.rs
@@ -26,6 +26,11 @@ impl Index {
         format!("Index: \"{name}\"", name = self.inner.name)
     }
 
+    #[getter]
+    pub fn name(&self) -> String {
+        self.inner.name.clone()
+    }
+
     #[pyo3(signature = (vectors, namespace="", async_req=false))]
     #[pyo3(text_signature = "(vectors, namespace='', async_req=False)")]
     /// The `Upsert` operation writes vectors into a namespace.

--- a/tests/grpc/test_multi_thread.py
+++ b/tests/grpc/test_multi_thread.py
@@ -1,0 +1,148 @@
+import sys
+from typing import Optional
+
+import pinecone
+import threading
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+import multiprocessing 
+import pytest
+from pinecone import Vector
+import pinecone 
+from ..utils.utils import index_fixture_factory
+from ..utils.remote_index import RemoteIndex, PodType
+import numpy as np
+import random 
+import time
+
+from ..unit.test_data_plane import get_test_data
+
+BATCH_SIZE = 100
+DIMENSION = 128
+TOP_K = 10
+
+test_mutli_thread = index_fixture_factory(
+    [
+         (RemoteIndex(pods=2, index_name=f'test-multi-thread-{PodType.P1}',
+                     dimension=DIMENSION, pod_type=PodType.P1), str(PodType.P1))
+    ]
+)
+
+def get_random_vectors(num, dim):
+    return [Vector(np.random.rand(dim).astype(np.float32).tolist()) for _ in range(num)]
+
+def make_upsert(index):
+    response = index.upsert(vectors=get_test_data(BATCH_SIZE, dimension=DIMENSION))
+    return response
+
+def make_query(index):
+    return index.query(values=np.random.rand(DIMENSION).astype(np.float32).tolist(),top_k=TOP_K)
+
+def check_upsert_results(results, num_expected):
+    total_vectors = 0
+    for res in results:
+        total_vectors += res.result().upserted_count
+    assert total_vectors == num_expected
+
+
+def test_multithreaded_upsert(test_mutli_thread):
+    index, _ = test_mutli_thread
+    num_threads = 10
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        results = []
+        for _ in range(num_threads):
+            results.append(executor.submit(make_upsert, index))
+        check_upsert_results(results, BATCH_SIZE * num_threads)
+
+
+def test_multithreaded_query(test_mutli_thread):
+    index, _ = test_mutli_thread
+    num_threads = 10
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        results = []
+        for _ in range(num_threads):
+            results.append(executor.submit(make_query, index))
+        for res in results:
+            assert len(res.result()) == TOP_K
+
+
+@pytest.mark.skip(reason="Multiprocessing using single Index object is currently not supported")
+def test_multiprocess_query(test_mutli_thread):
+    index, _ = test_mutli_thread
+    num_processes = multiprocessing.cpu_count()
+    with ProcessPoolExecutor(max_workers=num_processes) as executor:
+        results = []
+        for _ in range(num_processes):
+            results.append(executor.submit(make_query, index))
+        for res in results:
+            assert len(res.result()) == TOP_K
+
+@pytest.mark.skip(reason="Multiprocessing using single Index object is currently not supported")
+def test_multiprocess_upsert(test_mutli_thread):
+    index, _ = test_mutli_thread
+    num_processes = multiprocessing.cpu_count()
+    with ProcessPoolExecutor(max_workers=num_processes) as executor:
+        results = []
+        for _ in range(num_processes):
+            results.append(executor.submit(make_upsert, index))
+        check_upsert_results(results, BATCH_SIZE * num_processes)
+
+def create_client_and_make_grpc_call(index_name, client: Optional[pinecone.Client] = None):
+    if client is None:
+        client = pinecone.Client()
+    new_index = client.get_index(index_name)
+    make_query(new_index)
+
+@pytest.mark.parametrize("method", ["threads", "processes"])
+def test_simultaneous_connections(test_mutli_thread, method):
+    index, _ = test_mutli_thread
+    test_name = index.name
+    num_indexes = 10 if method == "processes" else multiprocessing.cpu_count()
+
+    pool_class = ThreadPoolExecutor if method == "threads" else ProcessPoolExecutor
+    with pool_class(max_workers=num_indexes) as executor:
+        results = []
+        for _ in range(num_indexes):
+            executor.submit(create_client_and_make_grpc_call, test_name)
+        for res in results:
+            assert len(res.result()) == TOP_K
+
+@pytest.mark.parametrize("method", ["threads", "processes"])
+def test_simultaneous_connections_existing_client(test_mutli_thread, method):
+    if sys.platform == 'darwin' and method == "processes":
+        pytest.skip("Passing Client object to ProcessPool is not supported on MacOS")
+
+    index, _ = test_mutli_thread
+    test_name = index.name
+    joint_client = pinecone.Client()
+    num_indexes = 10 if method == "processes" else multiprocessing.cpu_count()
+
+    pool_class = ThreadPoolExecutor if method == "threads" else ProcessPoolExecutor
+    with pool_class(max_workers=num_indexes) as executor:
+        results = []
+        for _ in range(num_indexes):
+            executor.submit(create_client_and_make_grpc_call, test_name, client=joint_client)
+        for res in results:
+            assert len(res.result()) == TOP_K
+
+@pytest.mark.slow
+def test_long_standing_connection(test_mutli_thread):
+    index, _ = test_mutli_thread
+    make_upsert(index)
+    time.sleep(2 * 60 * 60)
+    make_query(index)
+
+
+@pytest.mark.slow
+def test_random_delays_between_calls(test_mutli_thread):
+    num_calls = 10
+    min_delay = 0.1  # seconds
+    # gloo will send back fin around this mark if the connection is idle
+    max_delay = 300.0  # seconds
+    index, _  = test_mutli_thread
+    for _ in range(num_calls):
+        make_query(index)
+        delay = random.uniform(min_delay, max_delay)
+        # Add some sporadic longer delays
+        if random.random() < 0.2:
+            delay += 15.0 * 60.0
+        time.sleep(delay)


### PR DESCRIPTION
These changes were originally added in https://github.com/pinecone-io/client_sdk/pull/66, but were never merged.

I had to do some extensive refactoring. Apparently all the test cases simply received an async `Future()` and returned immediately - so nothing actually ran \ was tested.