### PR TITLE
Support passing SparseValues as dict to `query()`

### DIFF
--- a/client_sdk/src/data_types.rs
+++ b/client_sdk/src/data_types.rs
@@ -34,6 +34,14 @@ impl SparseValues {
             values = &self.values.chunks(5).next().unwrap_or(&Vec::<f32>::new())
         ))
     }
+
+    pub fn to_dict<'a>(&self, py: Python<'a>) -> &'a PyDict {
+        let key_vals: Vec<(&str, PyObject)> = vec![
+            ("indices", self.indices.to_object(py)),
+            ("values", self.values.to_object(py)),
+        ];
+        key_vals.into_py_dict(py)
+    }
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
## Problem

Before this change, the `upsert()` method accepted `SparseValues` both as an object or a `dict`, but the `query()` method accepted object only.

## Solution

Changed the input argument of `query()` to and Enum (a `Union` on the python side)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Added UTs - both simple and negative testsing.