### PR TITLE
Fix CI by pinning docker version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ clean:
 	rm -rf $(VENV_DIR)
 
 generate-index-service:
-	docker run --rm -v "${CURDIR}:/local" openapitools/openapi-generator-cli:latest-release generate --input-spec /local/openapi/index_service.json  --generator-name rust  --output /local/index_service --additional-properties packageName=index_service --additional-properties packageVersion=0.1.0 --additional-properties withSerde=true  --additional-properties supportMultipleResponses=true
+	docker run --rm -v "${CURDIR}:/local" openapitools/openapi-generator-cli:v6.3.0 generate --input-spec /local/openapi/index_service.json  --generator-name rust  --output /local/index_service --additional-properties packageName=index_service --additional-properties packageVersion=0.1.0 --additional-properties withSerde=true  --additional-properties supportMultipleResponses=true


### PR DESCRIPTION
## Problem

CI began failing because a new version of openapi was released and the compiled output of that build step changed.

## Solution

Pin to an older version of the openapi generator so builds will be reproducible and consistent.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

## Test Plan

Describe specific steps for validating this change.
