### PR TITLE
Migrate off abandoned rust setup action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
   generate_openapi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: pinecone_client
       - run: |
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate_openapi
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v3
       with:
         name: index-service
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate_openapi
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v3
       with:
         name: index-service
@@ -88,7 +88,7 @@ jobs:
       matrix:
         python_version: [ "python3.7", "python3.8", "python3.9", "python3.10", "python3.11" ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install protoc
       run: choco install protoc
     - uses: actions/download-artifact@v3
@@ -113,7 +113,7 @@ jobs:
       matrix:
         python_version: ["python3.7", "python3.8", "python3.9", "python3.10", "python3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v3
       with:
         name: index-service
@@ -139,7 +139,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [ macos, linux, linux_aa64, windows ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: wheels

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,10 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # TODO: make common install steps a separate action
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install Build Dependencies
         run: sudo apt-get -y update && sudo apt-get -y install pkg-config libssl-dev clang
       - name: Install protoc
@@ -35,10 +33,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 'pypy3.9'
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install Build Dependencies
         run: sudo apt-get -y update && sudo apt-get -y install pkg-config libssl-dev clang
       - name: Install protoc


### PR DESCRIPTION
## Problem

CI runs are currently showing 10 warnings related to set-output and deprecated node usage in the `actions-rs/toolchain` action. Looking at the github repo for that action, it has been abandoned by the maintainer.

See https://github.com/actions-rs/toolchain/issues/216

## Solution

Migrate CI to use an alternative setup action

## Type of Change

- [x] Infrastructure change (CI configs, etc)
